### PR TITLE
Add go.mod under echo-server to enable module-aware tests in CI.

### DIFF
--- a/echo-server/go.mod
+++ b/echo-server/go.mod
@@ -1,0 +1,3 @@
+module github.com/igor-kupczynski/http2-utils/echo-server
+
+go 1.20


### PR DESCRIPTION
Fixes GitHub Actions failure where go test ran in module mode at echo-server without a module. Keeps existing workflow intact; tests pass locally under Go 1.20.